### PR TITLE
Add PIF data source

### DIFF
--- a/website/docs/d/pif.md
+++ b/website/docs/d/pif.md
@@ -1,0 +1,30 @@
+---
+title: "xenserver_pif"
+---
+
+Provides information about a physical network interface (PIF) of a XenServer host specified by the interface name or whether it is the management interface.
+
+## Example Usage
+
+```hcl
+data "xenserver_pif" "eth0" {
+  device = "eth0"
+}
+
+data "xenserver_pif" "management" {
+  management = true
+}
+
+resource "xenserver_vm" "demo-vm" {
+  // ...
+  network_interface {
+    network_uuid = "${data.xenserver_pif.management.network_uuid}"
+    device = 0
+  }
+  network_interface {
+    network_uuid = "${data.xenserver_pif.eth0.network_uuid}"
+    device = 1
+  }
+  // ...
+}
+```

--- a/xenserver/data_source_pif.go
+++ b/xenserver/data_source_pif.go
@@ -1,0 +1,69 @@
+package xenserver
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceXenServerPif() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceXenServerPifRead,
+
+		Schema: map[string]*schema.Schema{
+			"device": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The machine-readable name of the interface (e.g. eth0)",
+				Optional:    true,
+			},
+			"management": &schema.Schema{
+				Type:        schema.TypeBool,
+				Description: "Indicates whether the control software is listening for connections on this interface",
+				Optional:    true,
+			},
+			// Computed values
+			"network_uuid": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "UUID of the virtual network to which this PIF is connected",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceXenServerPifRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Connection)
+
+	device, deviceOk := d.GetOk("device")
+	management, managementOk := d.GetOk("management")
+
+	if !deviceOk && !managementOk {
+		return fmt.Errorf("One of device or management must be assigned")
+	}
+
+	if pifs, err := c.client.PIF.GetAllRecords(c.session); err == nil {
+		found := false
+		for _, pif := range pifs {
+			if (!deviceOk || pif.Device == device) && (!managementOk || pif.Management == management) {
+				d.SetId(pif.UUID)
+
+				network := &NetworkDescriptor{
+					NetworkRef: pif.Network,
+				}
+				if err = network.Query(c); err != nil {
+					return err
+				}
+				d.Set("network_uuid", network.UUID)
+
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Matching PIF not found")
+		}
+	}
+
+	return nil
+}

--- a/xenserver/provider.go
+++ b/xenserver/provider.go
@@ -32,6 +32,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"xenserver_pif":  dataSourceXenServerPif(),
 			"xenserver_pifs": dataSourceXenServerPifs(),
 		},
 


### PR DESCRIPTION
Allows a Terraform configuration to dynamically determine network UUIDs associated with physical interfaces. For example:

    data "xenserver_pif" "eth0" {
      device = "eth0"
    }

    data "xenserver_pif" "management" {
      management = true
    }

    resource "xenserver_vm" "demo-vm" {
      // ...
      network_interface {
        network_uuid = "${data.xenserver_pif.management.network_uuid}"
        device = 0
      }
      network_interface {
        network_uuid = "${data.xenserver_pif.eth0.network_uuid}"
        device = 1
      }
      // ...
    }