### PR TITLE
 Add support for other_config to the network resource

### DIFF
--- a/website/docs/r/network.md
+++ b/website/docs/r/network.md
@@ -3,3 +3,16 @@ title: "xenserver_network"
 ---
 
 Provides a XenServer network resource.
+
+## Example Usage
+
+```hcl
+resource "xenserver_network" "demo" {
+  name_label = "Demo"
+  description = "Demo network from Terraform"
+  bridge = ""
+  other_config {
+    automatic = "false"
+  }
+}
+```

--- a/xenserver/resource_network.go
+++ b/xenserver/resource_network.go
@@ -30,6 +30,7 @@ const (
 	networkSchemaDescription = "description"
 	networkSchemaBridge      = "bridge"
 	networkSchemaMTU         = "mtu"
+	networkSchemaOtherConfig = "other_config"
 )
 
 func resourceNetwork() *schema.Resource {
@@ -61,6 +62,11 @@ func resourceNetwork() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
+			networkSchemaOtherConfig: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -68,11 +74,17 @@ func resourceNetwork() *schema.Resource {
 func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Connection)
 
+	var other_config = make(map[string]string)
+	for k, v := range d.Get(networkSchemaOtherConfig).(map[string]interface{}) {
+		other_config[k] = v.(string)
+	}
+
 	networkRecord := xenAPI.NetworkRecord{
 		NameLabel:       d.Get(networkSchemaName).(string),
 		NameDescription: d.Get(networkSchemaDescription).(string),
 		MTU:             d.Get(networkSchemaMTU).(int),
 		Bridge:          d.Get(networkSchemaBridge).(string),
+		OtherConfig:     other_config,
 	}
 
 	if networkRef, err := c.client.Network.Create(c.session, networkRecord); err == nil {


### PR DESCRIPTION
Useful when creating multiple networks that should not be added to new VMs by default, for example:

    resource "xenserver_network" "demo" {
      name_label = "Demo"
      description = "Demo network from Terraform"
      bridge = ""
      other_config {
        automatic = "false"
      }
    }