### PR TITLE
Set managed to true for Terraform created networks

### DIFF
--- a/xenserver/resource_network.go
+++ b/xenserver/resource_network.go
@@ -85,6 +85,7 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 		MTU:             d.Get(networkSchemaMTU).(int),
 		Bridge:          d.Get(networkSchemaBridge).(string),
 		OtherConfig:     other_config,
+		Managed:         true,
 	}
 
 	if networkRef, err := c.client.Network.Create(c.session, networkRecord); err == nil {


### PR DESCRIPTION
Using XenServer 7.4 I receive the following error when starting a VM with a newly Terraform created network:

    BRIDGE_NOT_AVAILABLE

XenCenter states: "Could not find bridge required by VM".

Setting `Managed` to `true` in the `NetworkRecord` fixes it for me.

Reproduce with:

    resource "xenserver_network" "test" {
      name_label = "test"
      description = "Test network"
      bridge = ""
    }

Then attach this new network to a VM. It will no longer start. 