### PR TITLE
Fix creation of non-template VBDs

### DIFF
--- a/xenserver/resource_vbd.go
+++ b/xenserver/resource_vbd.go
@@ -368,7 +368,7 @@ func createVBDs(c *Connection, s []interface{}, vbdType xenAPI.VbdType, vm *VMDe
 	for _, schm := range s {
 		data := schm.(map[string]interface{})
 
-		if _, ok := data[vbdSchemaUserDevice]; ok {
+		if data[vbdSchemaUserDevice] != "" {
 			continue
 		}
 

--- a/xenserver/resource_vbd.go
+++ b/xenserver/resource_vbd.go
@@ -213,7 +213,7 @@ func readVBDs(c *Connection, vm *VMDescriptor) ([]map[string]interface{}, []map[
 
 	hdd := make([]map[string]interface{}, 0, len(vmVBDs))
 	cdrom := make([]map[string]interface{}, 0, len(vmVBDs))
-	log.Println(fmt.Sprintf("[DEBUG] Got %d VDIs", len(vmVBDs)))
+	log.Println(fmt.Sprintf("[DEBUG] Got %d VBDs", len(vmVBDs)))
 
 	for _, _vbd := range vmVBDs {
 		vbd := VBDDescriptor{


### PR DESCRIPTION
vbdSchemaUserDevice is always present in the schema, so the loop always continues. Instead the value should be checked to ensure that it is blank which indicates a non-template VBD that must be created.

Reproduce with:

    resource "xenserver_vdi" "demo-vdi" {
      sr_uuid = "<UUID>"
      name_label = "demo-vdi"
      size = 5368709120
    }
    
    resource "xenserver_vm" "demo-vm" {
      name_label = "demo-vm"
      base_template_name = "ubuntu-1604"
      static_mem_min = 1073741824
      static_mem_max = 1073741824
      dynamic_mem_min = 1073741824
      dynamic_mem_max = 1073741824
      vcpus = 1
      boot_order = "c"
      hard_drive {
        user_device = "0"
        is_from_template = true
      }
      hard_drive {
        vdi_uuid = "${xenserver_vdi.demo-vdi.id}"
        mode = "RW"
      }
    }

The new VM and VDI will be created but the new disk will not be attached to the VM. Only the disk from the template will be present.

Adding debugging to the loop it can be seen that `user_device` is always present, but blank for non-template VBDs:

    map[user_device: bootable:false mode:RW is_from_template:false vdi_uuid:faebd98d-28bc-417d-86be-ebde768dc1b2]
    map[user_device: bootable:false mode:RW is_from_template:false vdi_uuid:faebd98d-28bc-417d-86be-ebde768dc1b2]