### PR TITLE
Add support for other_config to the VM resource

### DIFF
--- a/website/docs/r/vm.md
+++ b/website/docs/r/vm.md
@@ -33,6 +33,9 @@ resource "xenserver_vm" "web" {
     hard_drive {
       vdi_uuid = "<desired vdi>"
     }
+    other_config {
+        auto_poweron = "true"
+    }
 }
 ```
 
@@ -61,6 +64,8 @@ The `cdrom` block supports:
 The `hard_drive` block supports:
 
 * `vdi_uuid` - 
+
+The `other_config` block sets any number of given key-value pairs in the VM's `other-config` map.
 
 ## Attributes Reference
 

--- a/xenserver/resource_vm.go
+++ b/xenserver/resource_vm.go
@@ -45,6 +45,7 @@ const (
 	vmSchemaVcpus                     = "vcpus"
 	vmSchemaCoresPerSocket            = "cores_per_socket"
 	vmSchemaXenstoreData              = "xenstore_data"
+	vmSchemaOtherConfig               = "other_config"
 )
 
 func resourceVM() *schema.Resource {
@@ -145,6 +146,11 @@ func resourceVM() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			vmSchemaOtherConfig: &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -207,9 +213,14 @@ func resourceVMCreate(d *schema.ResourceData, m interface{}) error {
 	d.SetPartial(vmSchemaNameLabel)
 	d.SetId(vm.UUID)
 
-	// Reset base template name
 	otherConfig := vm.OtherConfig
+	for k, v := range d.Get(vmSchemaOtherConfig).(map[string]interface{}) {
+		otherConfig[k] = v.(string)
+	}
+
+	// Reset base template name
 	otherConfig["base_template_name"] = dBaseTemplateName
+
 	if err = c.client.VM.SetOtherConfig(c.session, vm.VMRef, otherConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
Example use is to enable automatic powering on of a VM:

    resource "xenserver_vm" "demo" {
      name_label = "Demo"
      # ...
      other_config {
        auto_poweron = "true"
      }
    }